### PR TITLE
add template rendering checks for ips with leading zeros for winc jobs

### DIFF
--- a/jobs/winc-network-hns-acls/templates/interface.json.erb
+++ b/jobs/winc-network-hns-acls/templates/interface.json.erb
@@ -1,4 +1,25 @@
 <%=
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+	begin
+	  parsed = IPAddr.new ip
+	rescue  => e
+	  raise "Invalid #{var_name} '#{ip}': #{e}"
+	end
+    end
+  end
+
+  def parse_ips(ips, var_name)
+    ips.each do |ip|
+      parse_ip(ip, var_name)
+    end
+  end
+
+  parse_ip(p('winc_network.subnet_range'), 'winc_network.subnet_range')
+  parse_ip(p('winc_network.gateway_address'), 'winc_network.gateway_address')
+  parse_ips(p('winc_network.dns_servers'), 'winc_network.dns_servers')
+
   toRender = {
     "mtu" => p("winc_network.mtu"),
     "network_name" => "winc-nat",

--- a/jobs/winc-network/templates/interface.json.erb
+++ b/jobs/winc-network/templates/interface.json.erb
@@ -1,4 +1,23 @@
 <%=
+  def parse_ip (ip, var_name)
+    unless ip.empty?
+      ip = ip.split(":")[0]
+	begin
+	  parsed = IPAddr.new ip
+	rescue  => e
+	  raise "Invalid #{var_name} '#{ip}': #{e}"
+	end
+    end
+  end
+
+  def parse_ips(ips, var_name)
+    ips.each do |ip|
+      parse_ip(ip, var_name)
+    end
+  end
+
+  parse_ips(p('winc_network.dns_servers'), 'winc_network.dns_servers')
+
   toRender = {
     "mtu" => p("winc_network.mtu"),
     "network_name" => "winc-nat",


### PR DESCRIPTION
Adds quicker errors when invalid IPs are used after upgrading to golang 1.17