### PR TITLE
Add template for credential spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ releases/**/*.tgz
 *#
 #*
 pkg
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+group :test do
+  gem 'rspec'
+  gem 'bosh-template'
+end

--- a/jobs/winc/spec
+++ b/jobs/winc/spec
@@ -1,10 +1,50 @@
 ---
 name: winc
 
-templates: {}
+templates:
+   credential_spec.json.erb: config/credential_spec.json
 
 packages:
 - nstar
 - winc
 
-properties: {}
+properties:
+  ccg.enabled:
+    description: When enabled, winc will pass a credential spec to HCS on container creation.
+    default: false
+
+  ccg.plugin_guid:
+    description: The curly-brace-enclosed GUID of the COM class which implements the ICcgDomainAuthCredentials::GetPasswordCredentials method. See https://docs.microsoft.com/en-us/windows/win32/api/ccgplugins/nf-ccgplugins-iccgdomainauthcredentials-getpasswordcredentials.
+    example: "{GDMA0342-266A-4D1P-831J-20990E82944F}"
+
+  ccg.plugin_input:
+    description: The input to the plugin used to resolve credentials from Active Directory. See https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts#additional-credential-spec-configuration-for-non-domain-joined-container-host-use-case
+
+  ccg.credential_spec:
+    description: JSON string describing the GMSA user account and domain details.  See https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts#create-a-credential-spec
+    example: |
+      {
+        "CmsPlugins": [
+          "ActiveDirectory"
+        ],
+        "DomainJoinConfig": {
+          "Sid": "S-1-5-21-702590844-1001920913-2680819671",
+          "MachineAccountName": "webapp01",
+          "Guid": "56d9b66c-d746-4f87-bd26-26760cfdca2e",
+          "DnsTreeName": "contoso.com",
+          "DnsName": "contoso.com",
+          "NetBiosName": "CONTOSO"
+        },
+        "ActiveDirectoryConfig": {
+          "GroupManagedServiceAccounts": [
+            {
+              "Name": "webapp01",
+              "Scope": "contoso.com"
+            },
+            {
+              "Name": "webapp01",
+              "Scope": "CONTOSO"
+            }
+          ]
+        }
+      }

--- a/jobs/winc/templates/credential_spec.json.erb
+++ b/jobs/winc/templates/credential_spec.json.erb
@@ -1,0 +1,89 @@
+<% if p('ccg.enabled') %>
+<%
+def validate_presence_or_raise(property)
+  if_p(property) do
+    return p(property)
+  end.else do
+    raise "#{property} is required when ccg.enabled is true"
+  end
+end
+
+# Example of valid structure
+# {
+#     "CmsPlugins": [
+#         "ActiveDirectory"
+#     ],
+#     "DomainJoinConfig": {
+#         "Sid": "S-1-5-21-702590844-1001920913-2680819671",
+#         "MachineAccountName": "webapp01",
+#         "Guid": "56d9b66c-d746-4f87-bd26-26760cfdca2e",
+#         "DnsTreeName": "contoso.com",
+#         "DnsName": "contoso.com",
+#         "NetBiosName": "CONTOSO"
+#     },
+#     "ActiveDirectoryConfig": {
+#         "GroupManagedServiceAccounts": [
+#             {
+#                 "Name": "webapp01",
+#                 "Scope": "contoso.com"
+#             },
+#             {
+#                 "Name": "webapp01",
+#                 "Scope": "CONTOSO"
+#             }
+#         ]
+#     }
+# }
+def validate_credential_spec_structure(config)
+  cms_plugins = config['CmsPlugins']
+  raise 'ccg.credential_spec must contain element "CmsPlugins"' if cms_plugins.nil?
+  raise 'ccg.credential_spec.CmsPlugins must be an array with a single element "ActiveDirectory"' if cms_plugins != ['ActiveDirectory']
+
+  domain_join_config = config['DomainJoinConfig']
+  raise 'ccg.credential_spec must contain element "DomainJoinConfig"' if domain_join_config.nil?
+  ['Sid', 'MachineAccountName', 'Guid', 'DnsTreeName', 'DnsName', 'NetBiosName'].each do |property|
+    raise "ccg.credential_spec.DomainJoinConfig must contain element \"#{property}\"" if domain_join_config[property].nil?
+  end
+
+  active_directory_config = config['ActiveDirectoryConfig']
+  raise 'ccg.credential_spec must contain element "ActiveDirectoryConfig"' if active_directory_config.nil?
+
+  group_managed_service_accounts = active_directory_config['GroupManagedServiceAccounts']
+  raise 'ccg.credential_spec.ActiveDirectoryConfig must contain element "GroupManagedServiceAccounts"' if group_managed_service_accounts.nil?
+  raise 'ccg.credential_spec.ActiveDirectoryConfig.GroupManagedServiceAccounts must be an array of objects with keys "Name" and "Scope"' unless group_managed_service_accounts.is_a?(Array)
+  raise 'ccg.credential_spec.ActiveDirectoryConfig.GroupManagedServiceAccounts must be an array of objects with keys "Name" and "Scope"' unless group_managed_service_accounts.all? do |e|
+    e.is_a?(Hash) && e.keys.sort == ['Name', 'Scope']
+  end
+end
+
+def validate_plugin_guid(guid)
+  raise 'ccg.plugin_guid must be a Microsoft GUID enclosed by curly braces' unless guid.start_with?('{') && guid.end_with?('}') && guid.length == 38
+end
+%>
+<%=
+  require 'json'
+
+  plugin_guid = validate_presence_or_raise('ccg.plugin_guid')
+  validate_plugin_guid(plugin_guid)
+  plugin_input = validate_presence_or_raise('ccg.plugin_input')
+  credential_spec = validate_presence_or_raise('ccg.credential_spec')
+
+  begin
+    parsed_credential_spec = JSON.parse(credential_spec)
+  rescue => e
+    raise "ccg.credential_spec must be valid json: #{e}"
+  end
+
+  validate_credential_spec_structure(parsed_credential_spec)
+
+  parsed_credential_spec['ActiveDirectoryConfig'].merge!({
+    'HostAccountConfig' => {
+      'PortableCcgVersion' => '1',
+      'PluginGUID' => plugin_guid,
+      'PluginInput' => plugin_input
+    }
+  })
+
+  JSON.pretty_generate(parsed_credential_spec)
+%>
+<% end %>

--- a/scripts/template-tests
+++ b/scripts/template-tests
@@ -1,0 +1,8 @@
+#!/bin/bash -exu
+
+ROOT_DIR_PATH="$(cd $(dirname $0)/.. && pwd)"
+
+pushd "${ROOT_DIR_PATH}" > /dev/null
+  bundle install
+  bundle exec rspec spec
+popd > /dev/null

--- a/scripts/test-using-fly.sh
+++ b/scripts/test-using-fly.sh
@@ -5,15 +5,19 @@ export GARDEN_WINDOWS_TARGET="garden-windows"
 
 groot_path="$HOME/workspace/winc-release/src/code.cloudfoundry.org/groot-windows"
 build_groot_task="$HOME/workspace/garden-windows-ci/tasks/build-groot/task.yml"
-groot_output=$(mktemp -d)
 
-echo "Building groot via ${build_groot_task}..."
-fly --target "$GARDEN_WINDOWS_TARGET" e -p \
-  --tag 2019 \
-  --inputs-from "winc/winc-2019" \
-  -i groot-windows="${groot_path}" \
-  -c "${build_groot_task}" \
-  -o groot-binary="${groot_output}"
+if [[ -f "${groot_path}/groot.exe" ]]; then
+    echo "groot binary already exists at ${groot_path}, using that one."
+else
+  echo "Building groot via ${build_groot_task}..."
+  fly --target "$GARDEN_WINDOWS_TARGET" e -p \
+    --tag 2019 \
+    --inputs-from "winc/winc-2019" \
+    -i groot-windows="${groot_path}" \
+    -c "${build_groot_task}" \
+    -o groot-binary="${groot_path}"
+fi
+
 
 winc_path="$HOME/workspace/winc-release/src/code.cloudfoundry.org/winc"
 build_winc_task="$HOME/workspace/garden-windows-ci/tasks/test-winc/task.yml"
@@ -25,8 +29,9 @@ export WINDOWS_VERSION=2019
 echo "Running task ${build_winc_task}"
 fly --target "$GARDEN_WINDOWS_TARGET" e -p \
   --tag 2019 \
-  --inputs-from "winc/winc-2019" \
+  --include-ignored \
   -i winc="${winc_path}" \
-  -i groot-binary="${groot_output}" \
+  -i ci="${HOME}/workspace/garden-windows-ci" \
+  -i groot-binary="${groot_path}" \
   -c "${build_winc_task}" \
   "$@"

--- a/spec/winc/winc_spec.rb
+++ b/spec/winc/winc_spec.rb
@@ -1,0 +1,312 @@
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+
+module Bosh::Template::Test
+  describe 'template rendering' do
+    let(:release_path) {File.join(File.dirname(__FILE__), '../..')}
+    let(:release) {ReleaseDir.new(release_path)}
+
+    describe 'winc job' do let(:job) {release.job('winc')}
+      describe 'credential_spec.json.erb' do
+        let(:template) {job.template('config/credential_spec.json')}
+
+        describe 'ccg disabled by default' do
+          let(:merged_manifest_properties) do
+            {}
+          end
+
+          it 'does not render anything in the credential spec file' do
+            rendered = template.render(merged_manifest_properties)
+            expect(rendered).to eq("\n")
+          end
+        end
+
+        describe 'ccg enabled' do
+          let(:credential_spec_raw) do
+            '{"CmsPlugins": [
+        "ActiveDirectory"
+        ],
+        "DomainJoinConfig": {
+          "Sid": "S-1-5-21-702590844-1001920913-2680819671",
+          "MachineAccountName": "webapp01",
+          "Guid": "56d9b66c-d746-4f87-bd26-26760cfdca2e",
+          "DnsTreeName": "contoso.com",
+          "DnsName": "contoso.com",
+          "NetBiosName": "CONTOSO"
+        },
+        "ActiveDirectoryConfig": {
+            "GroupManagedServiceAccounts": [
+                {
+                    "Name": "webapp01",
+                    "Scope": "contoso.com"
+                },
+                {
+                    "Name": "webapp01",
+                    "Scope": "CONTOSO"
+                }
+            ]
+        }}'
+          end
+          let(:merged_manifest_properties) do
+            {
+              'ccg' => {
+                'enabled' => true,
+                'plugin_guid' => '{e3c4e4bd-2dde-4676-8550-0aa07a736e2e}',
+                'plugin_input' => 'foo:bar@contoso.com',
+                'credential_spec' => credential_spec_raw
+              }
+            }
+          end
+
+
+          it 'renders the properties appropriately' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered).to eq({
+              'CmsPlugins' => [ "ActiveDirectory" ],
+              'DomainJoinConfig' => {
+                'Sid' => 'S-1-5-21-702590844-1001920913-2680819671',
+                'MachineAccountName' => 'webapp01',
+                'Guid' => '56d9b66c-d746-4f87-bd26-26760cfdca2e',
+                'DnsTreeName' => 'contoso.com',
+                'DnsName' => 'contoso.com',
+                'NetBiosName' => 'CONTOSO'
+              },
+              'ActiveDirectoryConfig' => {
+                'GroupManagedServiceAccounts' => [
+                  {
+                    'Name' => 'webapp01',
+                    'Scope' => 'contoso.com'
+                  },
+                  {
+                    'Name' => 'webapp01',
+                    'Scope' => 'CONTOSO'
+                  }
+                ],
+              'HostAccountConfig' => {
+                'PortableCcgVersion' => '1',
+                'PluginGUID' => '{e3c4e4bd-2dde-4676-8550-0aa07a736e2e}',
+                'PluginInput' => 'foo:bar@contoso.com'
+                }
+              }
+            })
+          end
+
+          describe 'validations' do
+            describe 'plugin guid' do
+              it 'validates presence' do
+                merged_manifest_properties['ccg']['plugin_guid'] = nil
+
+                expect do
+                  template.render(merged_manifest_properties)
+                end.to raise_error(/ccg.plugin_guid is required when ccg.enabled is true/)
+              end
+
+              it 'validates structure' do
+                merged_manifest_properties['ccg']['plugin_guid'] = "[totally-not-a-guid]"
+
+                expect do
+                  template.render(merged_manifest_properties)
+                end.to raise_error(/ccg.plugin_guid must be a Microsoft GUID enclosed by curly braces/)
+
+                merged_manifest_properties['ccg']['plugin_guid'] = "xGDMA0342-266A-4D1P-831J-20990E82944Fx"
+
+                expect do
+                  template.render(merged_manifest_properties)
+                end.to raise_error(/ccg.plugin_guid must be a Microsoft GUID enclosed by curly braces/)
+              end
+            end
+
+            describe 'plugin input' do
+              it 'validates presence of plugin input' do
+                merged_manifest_properties['ccg']['plugin_input'] = nil
+
+                expect do
+                  template.render(merged_manifest_properties)
+                end.to raise_error(/ccg.plugin_input is required when ccg.enabled is true/)
+              end
+            end
+
+            describe 'credential spec' do
+              it 'validates presence' do
+                merged_manifest_properties['ccg']['credential_spec'] = nil
+
+                expect do
+                  template.render(merged_manifest_properties)
+                end.to raise_error(/ccg.credential_spec is required when ccg.enabled is true/)
+              end
+
+              it 'validates json-ness' do
+                merged_manifest_properties['ccg']['credential_spec'] = "invalid json"
+
+                expect do
+                  template.render(merged_manifest_properties)
+                end.to raise_error(/ccg.credential_spec must be valid json:/)
+              end
+
+              describe 'validates structure' do
+                let(:credential_spec_parsed) { JSON.parse(credential_spec_raw) }
+
+                describe 'CmsPlugins' do
+                  it 'validates presence' do
+                    credential_spec_parsed.delete('CmsPlugins')
+                    merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                    expect do
+                      template.render(merged_manifest_properties)
+                    end.to raise_error(/ccg.credential_spec must contain element "CmsPlugins"/)
+                  end
+
+                  it 'has the correct structure' do
+                    credential_spec_parsed['CmsPlugins'] = 'asdf'
+                    merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                    expect do
+                      template.render(merged_manifest_properties)
+                    end.to raise_error(/ccg.credential_spec.CmsPlugins must be an array with a single element "ActiveDirectory"/)
+
+                    credential_spec_parsed['CmsPlugins'] = ['asdf']
+                    merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                    expect do
+                      template.render(merged_manifest_properties)
+                    end.to raise_error(/ccg.credential_spec.CmsPlugins must be an array with a single element "ActiveDirectory"/)
+                  end
+                end
+
+                describe 'DomainJoinConfig' do
+                  it 'validates presence' do
+                    credential_spec_parsed.delete('DomainJoinConfig')
+                    merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                    expect do
+                      template.render(merged_manifest_properties)
+                    end.to raise_error(/ccg.credential_spec must contain element "DomainJoinConfig"/)
+                  end
+
+                  describe 'validates children' do
+                    it 'has Sid' do
+                      credential_spec_parsed['DomainJoinConfig'].delete('Sid')
+                      merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                      expect do
+                        template.render(merged_manifest_properties)
+                      end.to raise_error(/ccg.credential_spec.DomainJoinConfig must contain element "Sid"/)
+                    end
+
+                    it 'has MachineAccountName' do
+                      credential_spec_parsed['DomainJoinConfig'].delete('MachineAccountName')
+                      merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                      expect do
+                        template.render(merged_manifest_properties)
+                      end.to raise_error(/ccg.credential_spec.DomainJoinConfig must contain element "MachineAccountName"/)
+                    end
+
+                    it 'has Guid' do
+                      credential_spec_parsed['DomainJoinConfig'].delete('Guid')
+                      merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                      expect do
+                        template.render(merged_manifest_properties)
+                      end.to raise_error(/ccg.credential_spec.DomainJoinConfig must contain element "Guid"/)
+                    end
+
+                    it 'has DnsTreeName' do
+                      credential_spec_parsed['DomainJoinConfig'].delete('DnsTreeName')
+                      merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                      expect do
+                        template.render(merged_manifest_properties)
+                      end.to raise_error(/ccg.credential_spec.DomainJoinConfig must contain element "DnsTreeName"/)
+                    end
+
+                    it 'has DnsName' do
+                      credential_spec_parsed['DomainJoinConfig'].delete('DnsName')
+                      merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                      expect do
+                        template.render(merged_manifest_properties)
+                      end.to raise_error(/ccg.credential_spec.DomainJoinConfig must contain element "DnsName"/)
+                    end
+
+                    it 'has NetBiosName' do
+                      credential_spec_parsed['DomainJoinConfig'].delete('NetBiosName')
+                      merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                      expect do
+                        template.render(merged_manifest_properties)
+                      end.to raise_error(/ccg.credential_spec.DomainJoinConfig must contain element "NetBiosName"/)
+                    end
+                  end
+                end
+
+                describe 'ActiveDirectoryConfig' do
+                  it 'validates presence' do
+                    credential_spec_parsed.delete('ActiveDirectoryConfig')
+                    merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                    expect do
+                      template.render(merged_manifest_properties)
+                    end.to raise_error(/ccg.credential_spec must contain element "ActiveDirectoryConfig"/)
+                  end
+
+                  it 'contains a single "GroupManagedServiceAccounts" child' do
+                    credential_spec_parsed['ActiveDirectoryConfig'].delete('GroupManagedServiceAccounts')
+                    merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                    expect do
+                      template.render(merged_manifest_properties)
+                    end.to raise_error(/ccg.credential_spec.ActiveDirectoryConfig must contain element "GroupManagedServiceAccounts"/)
+                  end
+
+                  describe 'GroupManagedServiceAccounts' do
+                    it 'is an array' do
+                      credential_spec_parsed['ActiveDirectoryConfig']['GroupManagedServiceAccounts'] = 'asdf'
+                      merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                      expect do
+                        template.render(merged_manifest_properties)
+                      end.to raise_error(/ccg.credential_spec.ActiveDirectoryConfig.GroupManagedServiceAccounts must be an array of objects with keys "Name" and "Scope"/)
+                    end
+
+                    describe 'entries' do
+                      it 'every entry is an hash' do
+                        credential_spec_parsed['ActiveDirectoryConfig']['GroupManagedServiceAccounts'] = ['asdf']
+                        merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                        expect do
+                          template.render(merged_manifest_properties)
+                        end.to raise_error(/ccg.credential_spec.ActiveDirectoryConfig.GroupManagedServiceAccounts must be an array of objects with keys "Name" and "Scope"/)
+                      end
+
+                      it 'each entry contains both "Name" and "Scope" keys' do
+                        credential_spec_parsed['ActiveDirectoryConfig']['GroupManagedServiceAccounts'] = [{'Name' => 'asdf'}]
+                        merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                        expect do
+                          template.render(merged_manifest_properties)
+                        end.to raise_error(/ccg.credential_spec.ActiveDirectoryConfig.GroupManagedServiceAccounts must be an array of objects with keys "Name" and "Scope"/)
+                      end
+
+                      it 'each entry ONLY contains "Name" and "Scope" keys' do
+                        credential_spec_parsed['ActiveDirectoryConfig']['GroupManagedServiceAccounts'] = [{'Name' => 'asdf', 'Scope' => 'bar', 'Fun' => 'times'}]
+                        merged_manifest_properties['ccg']['credential_spec'] = JSON.generate(credential_spec_parsed)
+
+                        expect do
+                          template.render(merged_manifest_properties)
+                        end.to raise_error(/ccg.credential_spec.ActiveDirectoryConfig.GroupManagedServiceAccounts must be an array of objects with keys "Name" and "Scope"/)
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is in support of Integrated Windows Auth. More details can be found here: https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/manage-serviceaccounts

There are fairly comprehensive template tests, as figuring out what went wrong after you've used an incorrect credential spec can be difficult.