### PR TITLE
Autocalculate overlay gateway IP addr based on subnet range

### DIFF
--- a/jobs/winc-network-hns-acls/spec
+++ b/jobs/winc-network-hns-acls/spec
@@ -22,7 +22,7 @@ properties:
     description: |
         Gateway address assigned to containers. When not specified, the first
         usable address in the subnet_range will be used. For example, if
-        subnet_range is specified as 192.168.1.0/24, it will choose 192.168.1.
+        subnet_range is specified as 192.168.1.0/24, it will choose 192.168.1.1
 
   winc_network.dns_servers:
     description: "DNS servers that containers will use. If not set, will use DNS settings from the host."

--- a/jobs/winc-network-hns-acls/spec
+++ b/jobs/winc-network-hns-acls/spec
@@ -19,8 +19,10 @@ properties:
     default: 172.30.0.0/22
 
   winc_network.gateway_address:
-    description: "Gateway address assigned to containers."
-    default: "172.30.0.1"
+    description: |
+        Gateway address assigned to containers. When not specified, the first
+        usable address in the subnet_range will be used. For example, if
+        subnet_range is specified as 192.168.1.0/24, it will choose 192.168.1.
 
   winc_network.dns_servers:
     description: "DNS servers that containers will use. If not set, will use DNS settings from the host."

--- a/jobs/winc-network-hns-acls/templates/addresses.json.erb
+++ b/jobs/winc-network-hns-acls/templates/addresses.json.erb
@@ -5,7 +5,7 @@
       if network.prefix < 1 || network.prefix > 30
 	raise 'subnet_range prefix length must be between 1 and 30'
       end
-      network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+      network.to_range.to_a[1].to_s #grab first usable IP in the subnet
     rescue => e
       raise "Invalid 'winc_network.subnet_range': #{e}"
     end

--- a/jobs/winc-network-hns-acls/templates/addresses.json.erb
+++ b/jobs/winc-network-hns-acls/templates/addresses.json.erb
@@ -1,6 +1,20 @@
 <%=
+  def gateway_for(subnet)
+    begin
+      network = IPAddr.new subnet
+      if network.prefix < 1 || network.prefix > 30
+	raise 'subnet_range prefix length must be between 1 and 30'
+      end
+      network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+    rescue => e
+      raise "Invalid 'winc_network.subnet_range': #{e}"
+    end
+  end
+
+  gateway = gateway_for(p('winc_network.subnet_range'))
+
   toRender = [{
-    "address" => "172.30.0.1",
+    "address" => gateway,
     "port" => 53,
   }]
 

--- a/jobs/winc-network-hns-acls/templates/interface.json.erb
+++ b/jobs/winc-network-hns-acls/templates/interface.json.erb
@@ -16,15 +16,35 @@
     end
   end
 
-  parse_ip(p('winc_network.subnet_range'), 'winc_network.subnet_range')
-  parse_ip(p('winc_network.gateway_address'), 'winc_network.gateway_address')
+  def gateway_for(subnet)
+    begin
+      network = IPAddr.new subnet
+      if network.prefix < 1 || network.prefix > 30
+	raise 'subnet_range prefix length must be between 1 and 30'
+      end
+
+      gateway = network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+      if_p('winc_network.gateway_address') do |gw|
+	 parse_ip(p('winc_network.gateway_address'), 'winc_network.gateway_address')
+	gateway = gw
+      end
+    rescue => e
+      raise "Invalid 'winc_network.subnet_range': #{e}"
+    end
+    if ! network.include?(gateway)
+      raise "Invalid 'winc_network.gateway_address': #{gateway} is outside the #{network}/#{network.prefix} subnet range"
+    end
+    gateway
+  end
+
   parse_ips(p('winc_network.dns_servers'), 'winc_network.dns_servers')
+  gateway = gateway_for(p('winc_network.subnet_range'))
 
   toRender = {
     "mtu" => p("winc_network.mtu"),
     "network_name" => "winc-nat",
     "subnet_range" => p("winc_network.subnet_range"),
-    "gateway_address" => p("winc_network.gateway_address"),
+    "gateway_address" => gateway,
     "dns_servers" => p("winc_network.dns_servers"),
     "maximum_outgoing_bandwidth" => p("winc_network.maximum_outgoing_bandwidth"),
     "search_domains" => p("winc_network.search_domains"),

--- a/jobs/winc-network-hns-acls/templates/interface.json.erb
+++ b/jobs/winc-network-hns-acls/templates/interface.json.erb
@@ -23,7 +23,7 @@
 	raise 'subnet_range prefix length must be between 1 and 30'
       end
 
-      gateway = network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+      gateway = network.to_range.to_a[1].to_s #grab first usable IP in the subnet
       if_p('winc_network.gateway_address') do |gw|
 	 parse_ip(p('winc_network.gateway_address'), 'winc_network.gateway_address')
 	gateway = gw

--- a/jobs/winc-network/spec
+++ b/jobs/winc-network/spec
@@ -21,3 +21,7 @@ properties:
   winc_network.maximum_outgoing_bandwidth:
     description: "Maximum outgoing bandwidth in bytes for each container. If 0, no limit is set. Values under 10KB are not respected by HNS"
     default: 0
+
+  winc_network.subnet_range:
+    default: "CIDR block for the subnet to use for container networking"
+    default: "172.30.0.0/22"

--- a/jobs/winc-network/templates/addresses.json.erb
+++ b/jobs/winc-network/templates/addresses.json.erb
@@ -5,7 +5,7 @@
       if network.prefix < 1 || network.prefix > 30
 	raise 'subnet_range prefix length must be between 1 and 30'
       end
-      network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+      network.to_range.to_a[1].to_s #grab first usable IP in the subnet
     rescue => e
       raise "Invalid 'winc_network.subnet_range': #{e}"
     end

--- a/jobs/winc-network/templates/addresses.json.erb
+++ b/jobs/winc-network/templates/addresses.json.erb
@@ -1,6 +1,20 @@
 <%=
+  def gateway_for(subnet)
+    begin
+      network = IPAddr.new subnet
+      if network.prefix < 1 || network.prefix > 30
+	raise 'subnet_range prefix length must be between 1 and 30'
+      end
+      network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+    rescue => e
+      raise "Invalid 'winc_network.subnet_range': #{e}"
+    end
+  end
+
+  gateway = gateway_for(p('winc_network.subnet_range'))
+
   toRender = [{
-    "address" => "172.30.0.1",
+    "address" => gateway,
     "port" => 53,
   }]
 

--- a/jobs/winc-network/templates/interface.json.erb
+++ b/jobs/winc-network/templates/interface.json.erb
@@ -16,13 +16,26 @@
     end
   end
 
+  def gateway_for(subnet)
+    begin
+      network = IPAddr.new subnet
+      if network.prefix < 1 || network.prefix > 30
+	raise 'subnet_range prefix length must be between 1 and 30'
+      end
+      network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+    rescue => e
+      raise "Invalid 'winc_network.subnet_range': #{e}"
+    end
+  end
+
   parse_ips(p('winc_network.dns_servers'), 'winc_network.dns_servers')
+  gateway = gateway_for(p('winc_network.subnet_range'))
 
   toRender = {
     "mtu" => p("winc_network.mtu"),
     "network_name" => "winc-nat",
-    "subnet_range" => "172.30.0.0/22",
-    "gateway_address" => "172.30.0.1",
+    "subnet_range" => p('winc_network.subnet_range'),
+    "gateway_address" => gateway,
     "dns_servers" => p("winc_network.dns_servers"),
     "maximum_outgoing_bandwidth" => p("winc_network.maximum_outgoing_bandwidth"),
   }

--- a/jobs/winc-network/templates/interface.json.erb
+++ b/jobs/winc-network/templates/interface.json.erb
@@ -22,7 +22,7 @@
       if network.prefix < 1 || network.prefix > 30
 	raise 'subnet_range prefix length must be between 1 and 30'
       end
-      network.to_range.to_a[1].to_s #grab first non-network IP in the subnet
+      network.to_range.to_a[1].to_s #grab first usable IP in the subnet
     rescue => e
       raise "Invalid 'winc_network.subnet_range': #{e}"
     end

--- a/spec/winc-network-hns-acls/addresses_json_spec.rb
+++ b/spec/winc-network-hns-acls/addresses_json_spec.rb
@@ -1,0 +1,50 @@
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+
+module Bosh::Template::Test
+  describe 'template rendering' do
+    let(:release_path) {File.join(File.dirname(__FILE__), '../..')}
+    let(:release) {ReleaseDir.new(release_path)}
+
+    describe 'winc-network-hns-acls' do let(:job) {release.job('winc-network-hns-acls')}
+      describe 'addresses.json.erb' do
+        let(:template) {job.template('dns/addresses.json')}
+
+        describe 'is backward compatible with installations not specifying subnet_range' do
+          let(:merged_manifest_properties) do
+            {
+            }
+          end
+
+          it 'renders the default addresses.json' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered).to eq([{
+              "address" => "172.30.0.1",
+              "port" => 53,
+            }])
+          end
+        end
+        describe 'when a valid subnet range is specified' do
+          let (:merged_manifest_properties) do
+            {
+              'winc_network' => {
+                'subnet_range' => '192.168.5.0/28',
+              },
+            }
+          end
+
+          it 'uses the calculated gateway addr as the default DNS entry' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered).to eq([{
+              "address" => "192.168.5.1",
+              "port" => 53,
+            }])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/winc-network-hns-acls/interface_json_spec.rb
+++ b/spec/winc-network-hns-acls/interface_json_spec.rb
@@ -1,0 +1,139 @@
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+
+module Bosh::Template::Test
+  describe 'template rendering' do
+    let(:release_path) {File.join(File.dirname(__FILE__), '../..')}
+    let(:release) {ReleaseDir.new(release_path)}
+
+    describe 'winc-network-hns-acls' do let(:job) {release.job('winc-network-hns-acls')}
+      describe 'interface.json.erb' do
+        let(:template) {job.template('config/interface.json')}
+
+        describe 'has backward compatible defaults' do
+          let(:merged_manifest_properties) do
+            {
+            }
+          end
+
+          it 'renders the default interfaces.json' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered).to eq({
+              "subnet_range" =>"172.30.0.0/22",
+              "gateway_address" => "172.30.0.1",
+              "mtu" => 0,
+              "network_name" => "winc-nat",
+              "maximum_outgoing_bandwidth" => 0,
+              "dns_servers" => [],
+              "search_domains" => [],
+              "allow_outbound_traffic_by_default" => false,
+              "wait_timeout_in_seconds" => 2,
+            })
+          end
+        end
+
+        describe 'when subnet_range is provided manually' do
+          let(:merged_manifest_properties) do
+            {
+              "winc_network" => {
+                  'subnet_range' => '192.168.5.0/28',
+              }
+            }
+          end
+          it 'uses the provided subnet' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered['subnet_range']).to eq("192.168.5.0/28")
+          end
+
+          describe 'when a gateway_addr is not specified' do
+            it 'chooses the first non-network address of the subnet' do
+              jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+              expect(jsonRendered['gateway_address']).to eq('192.168.5.1')
+            end
+          end
+
+          describe 'when gateway addr is provided manually' do
+            let(:merged_manifest_properties) do
+              {
+                "winc_network" => {
+                  'subnet_range' => '192.168.5.0/28',
+                  "gateway_address" => "192.168.5.5",
+                }
+              }
+            end
+
+            it 'uses the provided addr' do
+              jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+              expect(jsonRendered['gateway_address']).to eq('192.168.5.5')
+            end
+
+            describe 'but outside the subnet range' do
+            let(:merged_manifest_properties) do
+              {
+                "winc_network" => {
+                  'subnet_range' => '192.168.5.0/28',
+                  "gateway_address" => "192.168.5.100",
+                }
+              }
+            end
+              it 'raises an error' do
+                expect do
+                  template.render(merged_manifest_properties)
+                end.to raise_error /Invalid 'winc_network.gateway_address': /
+              end
+            end
+          end
+
+          describe 'when an invalid subnet range is specified' do
+            let (:merged_manifest_properties) do
+              {
+                'winc_network' => {
+                  'subnet_range' => '100.256.250.0/128',
+                },
+              }
+            end
+
+            it 'raises an error during template rendering' do
+              expect do
+                template.render(merged_manifest_properties)
+              end.to raise_error(/Invalid 'winc_network.subnet_range': /)
+            end
+          end
+          describe 'when subnet_range prefix length is < 1 bits' do
+            let (:merged_manifest_properties) do
+              {
+                'winc_network' => {
+                  'subnet_range' => '100.255.250.0/0',
+                },
+              }
+            end
+
+            it 'raises an error during template rendering' do
+              expect do
+                template.render(merged_manifest_properties)
+              end.to raise_error(/Invalid 'winc_network.subnet_range': subnet_range prefix length must be between 1 and 30/)
+            end
+          end
+          describe 'when subnet_range prefix length is > 30 bits' do
+            let (:merged_manifest_properties) do
+              {
+                'winc_network' => {
+                  'subnet_range' => '100.255.250.0/31',
+                },
+              }
+            end
+
+            it 'raises an error during template rendering' do
+              expect do
+                template.render(merged_manifest_properties)
+              end.to raise_error(/Invalid 'winc_network.subnet_range': subnet_range prefix length must be between 1 and 30/)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/winc-network-hns-acls/interface_json_spec.rb
+++ b/spec/winc-network-hns-acls/interface_json_spec.rb
@@ -49,7 +49,7 @@ module Bosh::Template::Test
           end
 
           describe 'when a gateway_addr is not specified' do
-            it 'chooses the first non-network address of the subnet' do
+            it 'chooses the first usable IP address of the subnet' do
               jsonRendered = JSON.parse(template.render(merged_manifest_properties))
               expect(jsonRendered['gateway_address']).to eq('192.168.5.1')
             end

--- a/spec/winc-network/addresses_json_spec.rb
+++ b/spec/winc-network/addresses_json_spec.rb
@@ -1,0 +1,50 @@
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+
+module Bosh::Template::Test
+  describe 'template rendering' do
+    let(:release_path) {File.join(File.dirname(__FILE__), '../..')}
+    let(:release) {ReleaseDir.new(release_path)}
+
+    describe 'winc-network' do let(:job) {release.job('winc-network')}
+      describe 'addresses.json.erb' do
+        let(:template) {job.template('dns/addresses.json')}
+
+        describe 'is backward compatible with installations not specifying subnet_range' do
+          let(:merged_manifest_properties) do
+            {
+            }
+          end
+
+          it 'renders the default addresses.json' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered).to eq([{
+              "address" => "172.30.0.1",
+              "port" => 53,
+            }])
+          end
+        end
+        describe 'when a valid subnet range is specified' do
+          let (:merged_manifest_properties) do
+            {
+              'winc_network' => {
+                'subnet_range' => '192.168.5.0/28',
+              },
+            }
+          end
+
+          it 'uses the calculated gateway addr as the default DNS entry' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered).to eq([{
+              "address" => "192.168.5.1",
+              "port" => 53,
+            }])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/winc-network/interface_json_spec.rb
+++ b/spec/winc-network/interface_json_spec.rb
@@ -1,0 +1,97 @@
+require 'rspec'
+require 'bosh/template/test'
+require 'yaml'
+require 'json'
+
+
+module Bosh::Template::Test
+  describe 'template rendering' do
+    let(:release_path) {File.join(File.dirname(__FILE__), '../..')}
+    let(:release) {ReleaseDir.new(release_path)}
+
+    describe 'winc-network' do let(:job) {release.job('winc-network')}
+      describe 'interface.json.erb' do
+        let(:template) {job.template('config/interface.json')}
+
+        describe 'is backward compatible with installations not specifying subnet_range' do
+          let(:merged_manifest_properties) do
+            {
+            }
+          end
+
+          it 'renders the default interfaces.json' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered).to eq({
+              "subnet_range" =>"172.30.0.0/22",
+              "gateway_address" => "172.30.0.1",
+              "mtu" => 0,
+              "network_name" => "winc-nat",
+              "maximum_outgoing_bandwidth" => 0,
+              "dns_servers" => [],
+            })
+          end
+        end
+        describe 'when a valid subnet range is specified' do
+          let (:merged_manifest_properties) do
+            {
+              'winc_network' => {
+                'subnet_range' => '192.168.5.0/28',
+              },
+            }
+          end
+
+          it 'chooses the first non-network address of the subnet' do
+            jsonRendered = JSON.parse(template.render(merged_manifest_properties))
+            expect(jsonRendered['subnet_range']).to eq('192.168.5.0/28')
+            expect(jsonRendered['gateway_address']).to eq('192.168.5.1')
+          end
+        end
+        describe 'when an invalid subnet range is specified' do
+          let (:merged_manifest_properties) do
+            {
+              'winc_network' => {
+                'subnet_range' => '100.256.250.0/128',
+              },
+            }
+          end
+
+          it 'raises an error during template rendering' do
+            expect do
+              template.render(merged_manifest_properties)
+            end.to raise_error(/Invalid 'winc_network.subnet_range': /)
+          end
+        end
+        describe 'when subnet_range prefix length is < 1 bits' do
+          let (:merged_manifest_properties) do
+            {
+              'winc_network' => {
+                'subnet_range' => '100.255.250.0/0',
+              },
+            }
+          end
+
+          it 'raises an error during template rendering' do
+            expect do
+              template.render(merged_manifest_properties)
+            end.to raise_error(/Invalid 'winc_network.subnet_range': subnet_range prefix length must be between 1 and 30/)
+          end
+        end
+        describe 'when subnet_range prefix length is > 30 bits' do
+          let (:merged_manifest_properties) do
+            {
+              'winc_network' => {
+                'subnet_range' => '100.255.250.0/31',
+              },
+            }
+          end
+
+          it 'raises an error during template rendering' do
+            expect do
+              template.render(merged_manifest_properties)
+            end.to raise_error(/Invalid 'winc_network.subnet_range': subnet_range prefix length must be between 1 and 30/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/winc-network/interface_json_spec.rb
+++ b/spec/winc-network/interface_json_spec.rb
@@ -40,7 +40,7 @@ module Bosh::Template::Test
             }
           end
 
-          it 'chooses the first non-network address of the subnet' do
+          it 'chooses the first usable IP address of the subnet' do
             jsonRendered = JSON.parse(template.render(merged_manifest_properties))
             expect(jsonRendered['subnet_range']).to eq('192.168.5.0/28')
             expect(jsonRendered['gateway_address']).to eq('192.168.5.1')


### PR DESCRIPTION
This allows operators to avoid having to manually specify the gateway_address in `winc-network-hns-acls`, and also allows operators to specify a custom `subnet_range` for `winc-network`. When not provided, the `gateway_address` will default to the first usable IP address of the subnet range.

If provided manually, the values for both subnet_range and gateway_address will be used, but throw errors if they are invalid for some reason. 

This also resolves an issue where bosh-dns may not have been working properly on installations that customized the subnet_range/gateway address from the defaults when using `winc-network-hns-acls`.