### PR TITLE
Sync env name for all runtime repos

### DIFF
--- a/scripts/fly/build-binaries.bash
+++ b/scripts/fly/build-binaries.bash
@@ -12,7 +12,7 @@ REPO_NAME=$(git_get_remote_name)
 REPO_PATH="${THIS_FILE_DIR}/../../"
 unset THIS_FILE_DIR
 
-if [[ "${WITH_CLEAN:-no}" == "yes" ]]; then
+if [[ "${CLEAN_CACHE:-no}" == "yes" ]]; then
   rm -rf "${BUILT_BINARIES}"
 fi
 


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
We use CLEAN_CACHE in other repos, so let's keep it the same for all
concourse related tests

Backward Compatibility
---------------
Breaking Change? **No**
