### PR TITLE
cleanup time format property

### DIFF
--- a/jobs/groot/spec
+++ b/jobs/groot/spec
@@ -31,10 +31,6 @@ properties:
     description: "Can be debug, info, error or fatal"
     default: "info"
 
-  groot.log_format:
-    description: "Can be rfc3339 or epoch"
-    default: "epoch"
-
   groot.refresh_base_layer:
     description: "EXPERIMENTAL: Delete size file in order to pull fresh base layer."
     default: false

--- a/jobs/groot/templates/groot.yml.erb
+++ b/jobs/groot/templates/groot.yml.erb
@@ -1,3 +1,2 @@
 ---
 log_level: <%= p("groot.log_level") %>
-log_format: <%= p("groot.log_format") %>


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
cleanup time format property
https://github.com/cloudfoundry/groot/pull/135 - merge and update the release tag in go.mod

Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
