### PR TITLE
nstar sanitizeDestination fails to block relative `..` traversal

### DIFF
--- a/src/code.cloudfoundry.org/nstar/nstar_windows.go
+++ b/src/code.cloudfoundry.org/nstar/nstar_windows.go
@@ -88,6 +88,12 @@ func sanitizeDestination(pid, username, path string) string {
 		destination = filepath.Join("c:\\", "proc", pid, "root", "Users", username, path)
 	}
 
+	containerRoot := filepath.Join("c:\\", "proc", pid, "root")
+	if !strings.HasPrefix(destination, containerRoot) {
+		fmt.Println("invalid path: resolved outside container root")
+		os.Exit(1)
+	}
+
 	return destination
 }
 

--- a/src/code.cloudfoundry.org/nstar/nstar_windows_test.go
+++ b/src/code.cloudfoundry.org/nstar/nstar_windows_test.go
@@ -280,9 +280,27 @@ var _ = Describe("Nstar", func() {
 	})
 
 	Context("when the path is a traversal attack", func() {
-		It("exits with an error", func() {
+		It("exits with an error on streamIn", func() {
 			stdout := gbytes.NewBuffer()
 			cmd := exec.Command(nstarBin, tarBin, "123", "some-user", `..\..\..\..\..\\Windows\\System32`)
+			session, err := gexec.Start(cmd, stdout, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(stdout).To(gbytes.Say("invalid path: traversal not permitted"))
+		})
+
+		It("exits with an error on streamOut", func() {
+			stdout := gbytes.NewBuffer()
+			cmd := exec.Command(nstarBin, tarBin, "123", "some-user", `..\..\..\..\..\\Windows\\System32`, "some-file")
+			session, err := gexec.Start(cmd, stdout, GinkgoWriter)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(session).Should(gexec.Exit(1))
+			Expect(stdout).To(gbytes.Say("invalid path: traversal not permitted"))
+		})
+
+		It("exits with an error for a single-segment traversal", func() {
+			stdout := gbytes.NewBuffer()
+			cmd := exec.Command(nstarBin, tarBin, "123", "some-user", `..`)
 			session, err := gexec.Start(cmd, stdout, GinkgoWriter)
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(1))


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
nstar sanitizeDestination should block relative `..` traversal


Backward Compatibility
---------------
Breaking Change? **No**
